### PR TITLE
Fixed an audition map manager bug causing crash

### DIFF
--- a/Code/CryEngine/CryAISystem/AuditionMap/AuditionMapRayCastManager.cpp
+++ b/Code/CryEngine/CryAISystem/AuditionMap/AuditionMapRayCastManager.cpp
@@ -64,6 +64,7 @@ SPendingListenerForStimulus::SPendingListenerForStimulus()
 
 SPendingListenerForStimulus::SPendingListenerForStimulus(const SPendingListenerForStimulus& other)
 	: listenerEntityId(other.listenerEntityId)
+	, stimulusParamsIndex(other.stimulusParamsIndex)
 	, queuedRayInfos(other.queuedRayInfos)
 {
 }
@@ -71,6 +72,7 @@ SPendingListenerForStimulus::SPendingListenerForStimulus(const SPendingListenerF
 void SPendingListenerForStimulus::Clear()
 {
 	listenerEntityId = INVALID_ENTITYID;
+	stimulusParamsIndex = -1;
 	queuedRayInfos.clear();
 }
 


### PR DESCRIPTION
(AI) Fixed a bug causing engine crash when there are more than one AI listener heard a sound event (with obstructionHandling = Perception::EStimulusObstructionHandling::RayCastWithLinearFallOff). This is caused by incomplete copy construction fcuntion called during std::vector<>::resize() in Perception::AuditionHelpers::CItemPool::Allocate()